### PR TITLE
GKE Cluster version updated

### DIFF
--- a/infra-setup/setup.sh
+++ b/infra-setup/setup.sh
@@ -4,7 +4,7 @@ export STUDENTCLUSTERNAME='k8s-training-cluster'
 export STUDENTREGION='us-central1'
 export STUDENTCLUSTER_MIN_NODES='2'
 export STUDENTCLUSTER_MAX_NODES='3'
-export STUDENTCLUSTER_VERSION='1.14.10-gke.36'
+export STUDENTCLUSTER_VERSION='1.16.9-gke.6'
 
 if [ -z "$STUDENTPROJECTNAME" ]; then
   export STUDENTPROJECTNAME='<Add-Project-Name>'


### PR DESCRIPTION
The existing `infra-setup/setup.sh` script raises the following error:
`ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.14.10-gke.36" is unsupported.
`
Although I was not able to find any official documentation, all versions other than `1.16.9-gke.6` from this [list](https://cloud.google.com/run/docs/gke/cluster-versions) raise the same error, so updated the `"STUDENTCLUSTER_VERSION"`